### PR TITLE
Gobbledygook in endpoints test

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -163,7 +163,7 @@ A successful response will include the name and email of the Giftbit account ass
     + Headers
 
             Authorization: Bearer YOUR_API_KEY
-            Accept-Encoding: gzip
+            Accept-Encoding: *
     
 + Response 200
     + Attributes

--- a/apiary.apib
+++ b/apiary.apib
@@ -163,6 +163,7 @@ A successful response will include the name and email of the Giftbit account ass
     + Headers
 
             Authorization: Bearer YOUR_API_KEY
+            Accept-Encoding: gzip
     
 + Response 200
     + Attributes

--- a/apiary.apib
+++ b/apiary.apib
@@ -163,7 +163,7 @@ A successful response will include the name and email of the Giftbit account ass
     + Headers
 
             Authorization: Bearer YOUR_API_KEY
-            Accept-Encoding: *
+            Accept-Encoding: identity
     
 + Response 200
     + Attributes


### PR DESCRIPTION
Adding "Accept-Encoding: gzip" to the /ping header as a check that the gobbledegook goes away for "Debugging Proxy" and "Production"

(Just trying for /ping for now, but should apply to all endpoints).

https://app.getflow.com/organizations/413714/teams/454183/tasks/42562667